### PR TITLE
SCI-952 Verify human middleware

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,10 @@ See conf.py for other settings
 Changelog
 ---------
 
+1.3.2
+~~~~~
+ - added confirm_human middleware
+
 1.3.1
 ~~~~~
  - added unittests for Jinja2 extension

--- a/README.rst
+++ b/README.rst
@@ -101,10 +101,20 @@ If you want to use the built in retention goals you will need to include the ret
 
     MIDDLEWARE_CLASSES [
         ...
+        'experiments.middleware.ConfirmHumanMiddleware',
         'experiments.middleware.ExperimentsRetentionMiddleware',
     ]
 
 *Note, more configuration options are detailed below.*
+
+
+Note: `ConfirmHumanMiddleware` is optional, not needed it you plan on running only template-based tests.
+If used, it should come after these classes:
+
+::
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+
 
 
 Jinja2:

--- a/experiments/middleware.py
+++ b/experiments/middleware.py
@@ -9,6 +9,7 @@ except ImportError:
 
 
 class ExperimentsRetentionMiddleware(MiddlewareMixin):
+
     def process_response(self, request, response):
         # Don't track, failed pages, ajax requests, logged out users or widget impressions.
         # We detect widgets by relying on the fact that they are flagged as being embedable
@@ -19,3 +20,9 @@ class ExperimentsRetentionMiddleware(MiddlewareMixin):
         experiment_user.visit()
 
         return response
+
+
+class ConfirmHumanMiddleware(MiddlewareMixin):
+
+    def process_request(self, request):
+        participant(request).confirm_human()

--- a/experiments/templatetags/experiments.py
+++ b/experiments/templatetags/experiments.py
@@ -11,10 +11,22 @@ from jinja2 import (
     nodes,
     TemplateSyntaxError,
 )
+import six
 
 from experiments.utils import participant
 from experiments.manager import experiment_manager
 from experiments import conf
+
+
+if six.PY2:
+    # Python 2's next() can't handle a non-iterator with a __next__ method.
+    _next = next
+    def next(obj, _next=_next):
+        if getattr(obj, '__next__', None):
+            return obj.__next__()
+        return _next(obj)
+
+    del _next
 
 
 register = template.Library()

--- a/experiments/tests/test_templatetags.py
+++ b/experiments/tests/test_templatetags.py
@@ -109,6 +109,8 @@ class ExperimentsJinjaExtensionTests(TestCase):
     def setUp(self):
         self.env = MagicMock()
         self.parser = MagicMock()
+        self.parser.stream.__iter__ = MagicMock()
+        self.parser.stream.__next__ = MagicMock()
         self.extension = ExperimentsExtension(self.env)
 
     def test_parse(self):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with codecs.open(path.join(PATH, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='consumeraffairs-django-experiments',
-    version='1.3.1',
+    version='1.3.2',
     description='Python Django AB Testing Framework',
     long_description=LONG_DESCRIPTION,
     author='ConsumerAffairs',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'django-jsonfield>=1.0.1',
         'redis>=2.4.9',
         'django-jinja>=2.3.1',
+        'six>=1.10.0',
     ],
     tests_require=[
         'mock>=1.0.1',


### PR DESCRIPTION
# SCI-952

## Story 

Decisions for some (most?) experiments are best done in Python code, before template rendering starts. For this to work with existing mechanism that filters out bots, we need to call the relevant function early enough. Best place do to that is a middleware class.

## Overview

This PR adds a new middleware class that calls `confirm_human` method. It was not added in the existing middleware because the two are both optional.

Also fixed failing tests in Python 2 due to changes in iterators

  