### PR TITLE
PUMA-105 threading fix for experiments auto-creating

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,10 @@ See conf.py for other settings
 Changelog
 ---------
 
+1.3.4
+~~~~~
+ - bugfix related to auto-create of experiments
+
 1.3.3
 ~~~~~
  - added experiment conditionals and auto-enrollment

--- a/experiments/manager.py
+++ b/experiments/manager.py
@@ -32,15 +32,20 @@ class ExperimentManager(ModelDict):
             return self.auto_create
 
     def _set_auto_crate_override(self, value):
-        thread_locals.django_experiments_manager_auto_create = value
+        if value is None:
+            try:
+                del thread_locals.django_experiments_manager_auto_create
+            except AttributeError:
+                pass
+        else:
+            thread_locals.django_experiments_manager_auto_create = value
 
     def get_experiment(self, experiment_name, auto_create=None):
         """
         Helper that mimics self[...] while allowing to override
         auto_create value.
         """
-        if auto_create is not None:
-            self._set_auto_crate_override(auto_create)
+        self._set_auto_crate_override(auto_create)
         try:
             return self[experiment_name]
         except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with codecs.open(path.join(PATH, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='consumeraffairs-django-experiments',
-    version='1.3.3rc1',
+    version='1.3.4',
     description='Python Django AB Testing Framework',
     long_description=LONG_DESCRIPTION,
     author='ConsumerAffairs',


### PR DESCRIPTION
When user is being enrolled in an experiment (e.g. by `{% experiment_enroll %}` tag), the experiment should be auto-created (provided a setting value is present). A recent PR needed to add an exception to this rule. But there was a bug in the exception, which this PR fixes.

Override flag for the auto-create flow mentioned above was added into thread `local` object. This was needed to keep the Model Dict Manager thread-safe. 
Value `None`  was supposed to signify a fall back to default implementation (i.e. respecting `self.auto_create` value), but an older value was left in `thread_locals.django_experiments_manager_auto_create` and so it remained in effect. This PR fixes that bug.

- [x] Test 1: Check that a test auto-creates
1. Open the experiments changelist in the admin
2. Open `click_experience` experiment
    * if not present, skip to step 4
3. Delete it, save
4. Open a wizard on FE
5. Refresh the experiments changelist in the admin, and verify that:
    * `click_experience` experiment is present again