### PR TITLE
PUMA-27 Some python2 fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,10 @@ See conf.py for other settings
 Changelog
 ---------
 
+1.3.5
+~~~~~
+ - bugfix for python2
+
 1.3.4
 ~~~~~
  - bugfix related to auto-create of experiments

--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,10 @@ See conf.py for other settings
 Changelog
 ---------
 
+1.3.6
+~~~~~
+ - compatibility improvements of unit tests
+
 1.3.5
 ~~~~~
  - bugfix for python2

--- a/experiments/admin.py
+++ b/experiments/admin.py
@@ -101,7 +101,8 @@ class ExperimentAdmin(admin.ModelAdmin):
         obj.save()
 
     def save_related(self, request, form, formsets, change):
-        super().save_related(request, form, formsets, change)
+        super(ExperimentAdmin, self).save_related(
+            request, form, formsets, change)
         self._update_obj_alternatives_dict(form.instance)
 
     def _update_obj_alternatives_dict(self, obj):

--- a/experiments/conditional/models.py
+++ b/experiments/conditional/models.py
@@ -105,7 +105,10 @@ class ContextTemplateMixin(models.Model):
 
     @staticmethod
     def _syntax_error_msg(exc):
-        return '{}, line {}: "{}"'.format(exc.msg, exc.lineno, exc.text)
+        try:
+            return '{}, line {}: "{}"'.format(exc.msg, exc.lineno, exc.text)
+        except:
+            return repr(exc)
 
 
 class AdminConditional(ContextTemplateMixin, models.Model):

--- a/experiments/conditional/models.py
+++ b/experiments/conditional/models.py
@@ -107,7 +107,7 @@ class ContextTemplateMixin(models.Model):
     def _syntax_error_msg(exc):
         try:
             return '{}, line {}: "{}"'.format(exc.msg, exc.lineno, exc.text)
-        except:
+        except AttributeError:
             return repr(exc)
 
 

--- a/experiments/static/experiments/dashboard/css/admin.css
+++ b/experiments/static/experiments/dashboard/css/admin.css
@@ -120,18 +120,32 @@ body.model-experiment .js-alternatives {
 }
 
 /* conditionals inline */
-#admin_conditionals-group .inline-related .form-row {
-    display: none;
-}
-#admin_conditionals-group .inline-related .form-row.copy_from {
+body.grp-change-form #admin_conditionals-group .inline-related.has_original .form-row {
     display: block;
 }
-#admin_conditionals-group .inline-related.has_original .form-row {
-    display: block;
-}
-#admin_conditionals-group .inline-related.has_original .form-row.copy_from {
+body.grp-change-form #admin_conditionals-group .inline-related.has_original .form-row.copy_from {
     display: none;
 }
+body.grp-change-form #admin_conditionals-group .inline-related .form-row {
+    display: none;
+}
+body.grp-change-form #admin_conditionals-group .inline-related .form-row.copy_from {
+    display: block;
+}
+
+body.change-form #admin_conditionals-group .inline-related .form-row {
+    display: block;
+}
+body.change-form #admin_conditionals-group .inline-related .form-row.field-copy_from {
+    display: none;
+}
+body.change-form #admin_conditionals-group .inline-related.last-related .form-row {
+    display: none;
+}
+body.change-form #admin_conditionals-group .inline-related.last-related .form-row.field-copy_from {
+    display: block;
+}
+
 
 /* misc */
 body.experiments-experiment table.relevant-goals,

--- a/experiments/templatetags/experiments.py
+++ b/experiments/templatetags/experiments.py
@@ -67,7 +67,7 @@ def experiments_prepare_conditionals(context):
 def _experiments_prepare_conditionals(context):
     Experiments(context)
     request = context['request']
-    if request.user.is_staff:
+    if getattr(request, 'user', None) and request.user.is_staff:
         report = json.dumps(request.experiments.report)
         script = '<script>window.ca_experiments = {};</script>'.format(
             report,

--- a/experiments/tests/test_admin.py
+++ b/experiments/tests/test_admin.py
@@ -1,15 +1,18 @@
+# coding=utf-8
 from __future__ import absolute_import
 import json
 
 from django.contrib.auth.models import User, Permission
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+from experiments.admin import ExperimentAdmin
 
 from experiments.models import Experiment, CONTROL_STATE, ENABLED_STATE
 from experiments.utils import participant
+from experiments.tests.testing_2_3 import mock
 
 
-class AdminTestCase(TestCase):
+class AdminAjaxTestCase(TestCase):
     def test_set_state(self):
         experiment = Experiment.objects.create(name='test_experiment', state=CONTROL_STATE)
         User.objects.create_superuser(username='user', email='deleted@mixcloud.com', password='pass')
@@ -77,3 +80,35 @@ class AdminTestCase(TestCase):
 
         self.assertEqual(400, self.client.post(reverse('admin:experiment_admin_set_state'), {}).status_code)
         self.assertEqual(400, self.client.post(reverse('admin:experiment_admin_set_alternative'), {}).status_code)
+
+
+class AdminTestCase(TestCase):
+
+    def test_set_default_alternative_called_when_changed(self):
+        obj = mock.MagicMock()
+        request = mock.MagicMock()
+        form = mock.MagicMock()
+        changed = True
+        model = Experiment
+        admin_site = mock.MagicMock()
+        admin_site = ExperimentAdmin(model, admin_site)
+
+        admin_site.save_model(request, obj, form, changed)
+
+        obj.set_default_alternative.assert_called_once_with(
+            form.cleaned_data['default_alternative'])
+        obj.save()
+
+    def test_set_default_alternative_called_when_not_changed(self):
+        obj = mock.MagicMock()
+        request = mock.MagicMock()
+        form = mock.MagicMock()
+        changed = False
+        model = Experiment
+        admin_site = mock.MagicMock()
+        admin_site = ExperimentAdmin(model, admin_site)
+
+        admin_site.save_model(request, obj, form, changed)
+
+        obj.set_default_alternative.assert_not_called()
+        obj.save()

--- a/experiments/tests/test_admin.py
+++ b/experiments/tests/test_admin.py
@@ -75,7 +75,9 @@ class AdminAjaxTestCase(TestCase):
         self.assertEqual(403, self.client.post(reverse('admin:experiment_admin_set_state'), {}).status_code)
         self.assertEqual(403, self.client.post(reverse('admin:experiment_admin_set_alternative'), {}).status_code)
 
-        permission = Permission.objects.get(codename='change_experiment')
+        permission = Permission.objects.get(
+            codename='change_experiment',
+            content_type__app_label='experiments')
         user.user_permissions.add(permission)
 
         self.assertEqual(400, self.client.post(reverse('admin:experiment_admin_set_state'), {}).status_code)

--- a/experiments/tests/test_webuser_incorporate.py
+++ b/experiments/tests/test_webuser_incorporate.py
@@ -53,30 +53,77 @@ def authenticated(incorporating):
     User = get_user_model()
     return AuthenticatedUser(user=User.objects.create(username=['incorporating_user', 'incorporated_user'][incorporating]))
 
-user_factories = (dummy, anonymous, authenticated)
+
+class Dummy2DummyIncorporateTestCase(WebUserIncorporateTestCase, TestCase):
+
+    def setUp(self):
+        super(Dummy2DummyIncorporateTestCase, self).setUp()
+        self.incorporating = dummy(True)
+        self.incorporated = dummy(False)
 
 
-def load_tests(loader, standard_tests, _):
-    suite = TestSuite()
-    suite.addTests(standard_tests)
+class Dummy2AnonymousIncorporateTestCase(WebUserIncorporateTestCase, TestCase):
 
-    for incorporating in user_factories:
-        for incorporated in user_factories:
-            test_case = build_test_case(incorporating, incorporated)
-            tests = loader.loadTestsFromTestCase(test_case)
-            suite.addTests(tests)
-    return suite
+    def setUp(self):
+        super(Dummy2AnonymousIncorporateTestCase, self).setUp()
+        self.incorporating = dummy(True)
+        self.incorporated = anonymous(False)
 
 
-def build_test_case(incorporating, incorporated):
-    class InstantiatedTestCase(WebUserIncorporateTestCase, TestCase):
+class Dummy2AuthenticatedIncorporateTestCase(WebUserIncorporateTestCase, TestCase):
 
-        def setUp(self):
-            super(InstantiatedTestCase, self).setUp()
-            self.incorporating = incorporating(True)
-            self.incorporated = incorporated(False)
-    InstantiatedTestCase.__name__ = "WebUserIncorporateTestCase_into_%s_from_%s" % (incorporating.__name__, incorporated.__name__)
-    return InstantiatedTestCase
+    def setUp(self):
+        super(Dummy2AuthenticatedIncorporateTestCase, self).setUp()
+        self.incorporating = dummy(True)
+        self.incorporated = authenticated(False)
+
+
+class Anonymous2DummyIncorporateTestCase(WebUserIncorporateTestCase, TestCase):
+
+    def setUp(self):
+        super(Anonymous2DummyIncorporateTestCase, self).setUp()
+        self.incorporating = anonymous(True)
+        self.incorporated = dummy(False)
+
+
+class Anonymous2AnonymousIncorporateTestCase(WebUserIncorporateTestCase, TestCase):
+
+    def setUp(self):
+        super(Anonymous2AnonymousIncorporateTestCase, self).setUp()
+        self.incorporating = anonymous(True)
+        self.incorporated = anonymous(False)
+
+
+class Anonymous2AuthenticatedIncorporateTestCase(WebUserIncorporateTestCase, TestCase):
+
+    def setUp(self):
+        super(Anonymous2AuthenticatedIncorporateTestCase, self).setUp()
+        self.incorporating = anonymous(True)
+        self.incorporated = authenticated(False)
+
+
+class Authenticated2DummyIncorporateTestCase(WebUserIncorporateTestCase, TestCase):
+
+    def setUp(self):
+        super(Authenticated2DummyIncorporateTestCase, self).setUp()
+        self.incorporating = authenticated(True)
+        self.incorporated = dummy(False)
+
+
+class Authenticated2AnonymousIncorporateTestCase(WebUserIncorporateTestCase, TestCase):
+
+    def setUp(self):
+        super(Authenticated2AnonymousIncorporateTestCase, self).setUp()
+        self.incorporating = authenticated(True)
+        self.incorporated = anonymous(False)
+
+
+class Authenticated2AuthenticatedIncorporateTestCase(WebUserIncorporateTestCase, TestCase):
+
+    def setUp(self):
+        super(Authenticated2AuthenticatedIncorporateTestCase, self).setUp()
+        self.incorporating = authenticated(True)
+        self.incorporated = authenticated(False)
 
 
 class IncorporateTestCase(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with codecs.open(path.join(PATH, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='consumeraffairs-django-experiments',
-    version='1.3.4',
+    version='1.3.5',
     description='Python Django AB Testing Framework',
     long_description=LONG_DESCRIPTION,
     author='ConsumerAffairs',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with codecs.open(path.join(PATH, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='consumeraffairs-django-experiments',
-    version='1.3.5',
+    version='1.3.6',
     description='Python Django AB Testing Framework',
     long_description=LONG_DESCRIPTION,
     author='ConsumerAffairs',


### PR DESCRIPTION
Forgot to call `super()` with arguments for Python 2. 

Also added unit tests to cover this particular method, since it wasn't being covered.

And finally a CSS fix for the default (non-Grappelli) admin skin. Was keeping compatibility but a bug slipped through, related to toggling fields when creating a new conditional inline.

Practicals will be run as part of PUMA-27 PR for the main site.