### PR TITLE
RED-10 toggle experiment state via dashboard

### DIFF
--- a/experiments/api/admin.py
+++ b/experiments/api/admin.py
@@ -49,9 +49,10 @@ class RemoteExperimentAdmin(admin.ModelAdmin):
 
         def link(state):
             return (
-                '<a href="#" data-state="{code}" class="{active}">{label}</a>'
+                '<a href="#" data-state="{code}" data-id="{id}" class="{active}">{label}</a>'
                 .format(
                     code=state,
+                    id=obj.id,
                     label=states[state],
                     active='active' if obj.state == state else '',
                 ))

--- a/experiments/api/admin.py
+++ b/experiments/api/admin.py
@@ -57,9 +57,8 @@ class RemoteExperimentAdmin(admin.ModelAdmin):
                     active='active' if obj.state == state else '',
                 ))
 
-        return '<div class="state_toggle">{}</div>'.format(
-            ''.join([link(s) for s in states])
-        )
+        html = ''.join(link(s) for s in states)
+        return '<div class="state_toggle">{}</div>'.format(html)
     state_toggle.short_description = 'state'
     state_toggle.allow_tags = True
     state_toggle.admin_order_field = 'state'

--- a/experiments/api/admin.py
+++ b/experiments/api/admin.py
@@ -3,6 +3,7 @@ import logging
 
 from django.contrib import admin
 
+from experiments.consts import STATES
 from .models import RemoteExperiment
 
 
@@ -19,7 +20,7 @@ class RemoteExperimentAdmin(admin.ModelAdmin):
     list_display = (
         'admin_link',
         'site',
-        'state',
+        'state_toggle',
         'start_date',
         'end_date',
         'participants',
@@ -42,6 +43,25 @@ class RemoteExperimentAdmin(admin.ModelAdmin):
     admin_link.short_description = 'name'
     admin_link.allow_tags = True
     admin_link.admin_order_field = 'name'
+
+    def state_toggle(self, obj):
+        states = dict(STATES)
+
+        def link(state):
+            return (
+                '<a href="#" data-state="{code}" class="{active}">{label}</a>'
+                .format(
+                    code=state,
+                    label=states[state],
+                    active='active' if obj.state == state else '',
+                ))
+
+        return '<div class="state_toggle">{}</div>'.format(
+            ''.join([link(s) for s in states])
+        )
+    state_toggle.short_description = 'state'
+    state_toggle.allow_tags = True
+    state_toggle.admin_order_field = 'state'
 
     def participants(self, obj):
         return sum(dict(obj.statistics['alternatives']).values())

--- a/experiments/api/models.py
+++ b/experiments/api/models.py
@@ -148,3 +148,22 @@ class RemoteExperiment(models.Model):
     def _cleanup(cls, batch):
         """Deletes all previous batches"""
         cls.objects.filter(batch__lt=batch).delete()
+
+    @property
+    def remote_payload(self):
+        """
+        Payload used for PATCH requests to change experiment state remotely
+        """
+        return {
+            'state': self.state,
+        }
+
+    @property
+    def remote_token(self):
+        """
+        Token from `EXPERIMENTS_API` settings for site that
+        is the origin of this instance.
+        """
+        for server in conf.API['remotes']:
+            if self.url.startswith(server['url']):
+                return server['token']

--- a/experiments/api/tests/test_admin.py
+++ b/experiments/api/tests/test_admin.py
@@ -108,6 +108,18 @@ class AdminTestCase(TestCase):
         self.assertIn('<a href', value)
         self.assertIn('Some admin URL', value)
 
+    def test_state_toggle(self):
+        value = self.modeladmin.state_toggle(self.obj)
+        self.assertIn('<a href', value)
+        self.assertIn('Default/Control', value)
+        self.assertIn('data-id="{}"'.format(self.obj.id), value)
+
+    @mock.patch('experiments.api.admin.STATES')
+    def test_state_toggle_w_no_states_lol(self, STATES):
+        STATES = {}
+        value = self.modeladmin.state_toggle(self.obj)
+        self.assertEqual('<div class="state_toggle"></div>', value)
+
     def test_participants(self):
         value = self.modeladmin.participants(self.obj)
         self.assertEqual(66, value)

--- a/experiments/api/tests/test_models.py
+++ b/experiments/api/tests/test_models.py
@@ -6,7 +6,6 @@ from experiments.consts import CONTROL_STATE
 from experiments.tests.testing_2_3 import mock
 
 
-
 class ModelsTestCase(TestCase):
 
     def setUp(self):
@@ -249,3 +248,32 @@ class ModelsTestCase(TestCase):
             ({'result': 3}, {'name': 'Test Site'}),
         ]
         self.assertEqual(list(value), expected_result)
+
+    def test_remote_payload(self):
+        instance = RemoteExperiment(state=3)
+        expected = {'state': 3}
+        self.assertEqual(instance.remote_payload, expected)
+
+    @mock.patch('experiments.api.models.conf')
+    def test_remote_token(self, conf):
+        conf.API = {
+            'remotes': [
+                {'url': 'url1', 'token': 'token1'},
+                {'url': 'url2', 'token': 'token2'},
+                {'url': 'url3', 'token': 'token3'},
+            ]
+        }
+        instance = RemoteExperiment(url='url2222')
+        self.assertEqual(instance.remote_token, 'token2')
+
+    @mock.patch('experiments.api.models.conf')
+    def test_remote_token_unknown(self, conf):
+        conf.API = {
+            'remotes': [
+                {'url': 'url1', 'token': 'token1'},
+                {'url': 'url2', 'token': 'token2'},
+                {'url': 'url3', 'token': 'token3'},
+            ]
+        }
+        instance = RemoteExperiment(url='url7777')
+        self.assertIsNone(instance.remote_token)

--- a/experiments/api/tests/test_models.py
+++ b/experiments/api/tests/test_models.py
@@ -50,7 +50,7 @@ class ModelsTestCase(TestCase):
             (mock.call(blocking=False), mock.call(blocking=True)))
         mock_lock.release.assert_called_once_with()
 
-    @mock.patch('experiments.conf')
+    @mock.patch('experiments.api.models.conf')
     def test_update_remotes_wo_remotes(self, patched_conf):
         patched_conf.API['remotes'] = []
         mock_lock = mock.MagicMock()

--- a/experiments/api/tests/test_v1.py
+++ b/experiments/api/tests/test_v1.py
@@ -1,12 +1,16 @@
 # coding=utf-8
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.utils import timezone
+
+from experiments.api.models import RemoteExperiment
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from experiments.api.v1.views import (
     APIRootView,
     ExperimentsListView,
     ExperimentView,
+    RemoteExperimentStateView,
 )
 import experiments
 from experiments.models import Experiment
@@ -110,3 +114,82 @@ class ApiTestCase(TestCase):
         response = view(self.request, name='exp2')
         self.assertEqual(403, response.status_code)
         self.assertEqual(b'', response.content)
+
+
+class RemoteExperimentStateViewTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.user = User.objects.create(
+            username='tester',
+            is_staff=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete()
+
+    def setUp(self):
+        self.request = APIRequestFactory().patch('')
+        force_authenticate(self.request, user=self.user)
+        RemoteExperiment.objects.all().delete()
+        self.kwargs = {
+            'site': 'Some remote site',
+            'name': 'Some experiment',
+            'url': 'Some URL',
+            'admin_url': 'Some admin URL',
+            'state': 1,
+            'start_date': timezone.datetime(2001, 2, 3, 0, 1, 2),
+            'end_date': timezone.datetime(2001, 2, 3, 3, 4, 5),
+            'alternatives_list': ['alt1', 'alt2', 'control'],
+            'statistics': {'much': 'data'},
+            'batch': 14,
+        }
+        self.instance = RemoteExperiment.objects.create(**self.kwargs)
+        self.factory = APIRequestFactory()
+        self.view = RemoteExperimentStateView().as_view()
+
+    @mock.patch('experiments.api.v1.views.requests')
+    @mock.patch(
+        'experiments.api.v1.views.RemoteExperimentStateView._check_response')
+    def test_success(self, _check_response, requests):
+        remote_response = requests.patch.return_value
+        remote_data = remote_response.json.return_value
+
+        response = self.view(self.request, pk=self.instance.id)
+
+        self.assertEqual(response.status_code, 200)
+        _check_response.assert_called_once_with(remote_data, self.instance)
+
+    @mock.patch('experiments.api.v1.views.requests')
+    @mock.patch(
+        'experiments.api.v1.views.RemoteExperimentStateView._check_response')
+    def test_exception(self, _check_response, requests):
+        remote_response = requests.patch.return_value
+        remote_response.json.side_effect = ValueError('OMG!')
+
+        response = self.view(self.request, pk=self.instance.id)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.data, {'detail': "ValueError('OMG!',)"})
+        _check_response.assert_not_called()
+
+    def test_check_response_same(self):
+        view = RemoteExperimentStateView()
+        remote_data = {'state': 0}
+
+        with mock.patch.object(view, 'queryset') as queryset:
+            view._check_response(remote_data, self.instance)
+
+        queryset.filter.asswer_not_called()
+
+    def test_check_response_different(self):
+        view = RemoteExperimentStateView()
+        remote_data = {'state': 3}
+
+        with mock.patch.object(view, 'queryset') as queryset:
+            view._check_response(remote_data, self.instance)
+
+        queryset.filter.asswer_called_once_with(id=self.instance.id)
+        update = queryset.filter.return_value.update
+        update.assert_called_once_with(state=3)

--- a/experiments/api/tests/test_v1.py
+++ b/experiments/api/tests/test_v1.py
@@ -123,6 +123,7 @@ class RemoteExperimentStateViewTestCase(TestCase):
         cls.user = User.objects.create(
             username='tester',
             is_staff=True,
+            is_active=True,
         )
 
     @classmethod
@@ -149,10 +150,12 @@ class RemoteExperimentStateViewTestCase(TestCase):
         self.factory = APIRequestFactory()
         self.view = RemoteExperimentStateView().as_view()
 
+    @mock.patch('experiments.api.v1.views.conf')
     @mock.patch('experiments.api.v1.views.requests')
     @mock.patch(
         'experiments.api.v1.views.RemoteExperimentStateView._check_response')
-    def test_success(self, _check_response, requests):
+    def test_success(self, _check_response, requests, conf):
+        conf.API = {'api_mode': 'cllient,server'}
         remote_response = requests.patch.return_value
         remote_data = remote_response.json.return_value
 
@@ -161,10 +164,12 @@ class RemoteExperimentStateViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         _check_response.assert_called_once_with(remote_data, self.instance)
 
+    @mock.patch('experiments.api.v1.views.conf')
     @mock.patch('experiments.api.v1.views.requests')
     @mock.patch(
         'experiments.api.v1.views.RemoteExperimentStateView._check_response')
-    def test_exception(self, _check_response, requests):
+    def test_exception(self, _check_response, requests, conf):
+        conf.API = {'api_mode': 'cllient,server'}
         remote_response = requests.patch.return_value
         remote_response.json.side_effect = ValueError('OMG!')
 

--- a/experiments/api/v1/serializers.py
+++ b/experiments/api/v1/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from rest_framework.reverse import reverse
 
 from ... import conf
+from ..models import RemoteExperiment
 from ...admin_utils import get_experiment_stats
 from ...models import Experiment
 
@@ -113,3 +114,10 @@ class ExperimentNestedSerializer(ExperimentSerializer):
 
     def get_alternatives_list(self, obj):
         return list(obj.alternatives.keys())
+
+
+class RemoteExperimentStateSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = RemoteExperiment
+        fields = ('state',)

--- a/experiments/api/v1/urls.py
+++ b/experiments/api/v1/urls.py
@@ -7,6 +7,8 @@ from .views import (
     APIRootView,
     ExperimentsListView,
     ExperimentView,
+    RemoteExperimentStateView,
+    RemoteExperimentView,
 )
 
 
@@ -29,4 +31,14 @@ urlpatterns = [
     url(r'^experiment/(?P<name>[-\w]+)/$',
         ExperimentView.as_view(),
         name='experiment'),
+
+    url(r'^remote_experiment/$',
+        RemoteExperimentView.as_view(),
+        name='remote_experiments'),
+
+    url(r'^remote_experiment/(?P<pk>[0-9]+)/state/$',
+        RemoteExperimentStateView.as_view(),
+        name='remote_experiment_state'),
+
+
 ]

--- a/experiments/api/v1/views.py
+++ b/experiments/api/v1/views.py
@@ -1,30 +1,34 @@
 # coding=utf-8
 import logging
 
-from django.http import HttpResponseNotAllowed, HttpResponse
+import requests
+from django.http import HttpResponse
 from rest_framework.authentication import (
     TokenAuthentication,
     SessionAuthentication,
 )
+from rest_framework.exceptions import APIException
 from rest_framework.generics import (
     ListAPIView,
     RetrieveUpdateAPIView,
+    GenericAPIView,
 )
+from rest_framework.mixins import UpdateModelMixin, RetrieveModelMixin
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
-from rest_framework.status import HTTP_204_NO_CONTENT, HTTP_403_FORBIDDEN
-from rest_framework.views import (
-    APIView,
-)
+from rest_framework.status import HTTP_403_FORBIDDEN
+from rest_framework.views import APIView
 
 from ... import conf
 from ...models import Experiment
+from ..models import RemoteExperiment
 from .paginators import DefaultPaginator
 from .serializers import (
     ExperimentNestedSerializer,
     ExperimentSerializer,
     SiteSerializer,
+    RemoteExperimentStateSerializer,
 )
 
 logger = logging.getLogger(__file__)
@@ -39,6 +43,9 @@ class APIRootView(APIView):
         if 'server' in conf.API['api_mode']:
             data['experiments'] = reverse(
                 'experiments:api:v1:experiments', request=request)
+        if 'client' in conf.API['api_mode']:
+            data['remote_experiments'] = reverse(
+                'experiments:api:v1:remote_experiments', request=request)
         return Response(data)
 
 
@@ -63,3 +70,68 @@ class ExperimentView(AuthMixin, RetrieveUpdateAPIView):
     lookup_field = 'name'
     lookup_url_kwarg = 'name'
     serializer_class = ExperimentSerializer
+
+
+class RemoteExperimentView(AuthMixin, APIView):
+    """
+    ## Remote Experiment proxy
+
+    This part of the API updates locally stored `RemoteExperiment`
+    models, but vefore save each update is pushed to the remote API
+    from where the `RemoteExperiment` instance originated.
+
+    To toggle experiment state, go to
+    [/experiments/api/v1/remote_experiment/EXPERIMENT_ID/toggle/](./EXPERIMENT_ID/toggle/)
+    endpoint.
+    Replace `EXPERIMENT_ID` with id of the local `RemoteExperiment` instance.
+    """
+
+
+class RemoteExperimentStateView(AuthMixin, RetrieveUpdateAPIView):
+    """
+    This endpoint acts as a proxy between admin jQuery code and
+    an ExperimentView API endpoint on a remote site.
+    """
+    queryset = RemoteExperiment.objects.all()
+    serializer_class = RemoteExperimentStateSerializer
+
+    def perform_update(self, serializer):
+        """
+        Performs the intended action. Request data has been
+        validated at this point.
+
+        Before updating the local DB instance (the usual action),
+        we need to update the remote instance as well, and then
+        only then we update the local data accordingly to avoid
+        inconsistencies.
+        """
+        serializer.save()  # needed at this point because serializer internals
+        try:
+            remote_data = self._remote_patch(
+                serializer.instance, serializer.data)
+        except Exception as e:
+            raise APIException(repr(e))
+        self._check_response(remote_data, serializer.instance)
+
+    def _remote_patch(self, instance, data):
+        """Issues the actual HTTP request"""
+        headers = {
+            'Authorization': 'Token {}'.format(instance.remote_token)
+        }
+        response = requests.patch(
+            instance.url,
+            data,
+            headers=headers,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _check_response(self, remote_data, instance):
+        """
+        Compares returned data to local and update if needed.
+        The update should happen only in case of errors, because
+        `serializer.save()` has already been called.
+        """
+        remote_state = remote_data['state']
+        if remote_state != instance.state:
+            self.queryset.filter(id=instance.id).update(state=remote_state)

--- a/experiments/static/experiments/dashboard/css/admin.css
+++ b/experiments/static/experiments/dashboard/css/admin.css
@@ -176,23 +176,36 @@ body.change-form #admin_conditionals-group .inline-related.last-related .form-ro
 }
 
 /* remote expderiments state toggle */
-#changelist .field-state_toggle .state_toggle {
+#changelist .field-state_toggle .state_toggle,
+.grp-change-list .field-state_toggle .state_toggle {
     white-space: nowrap;
 }
-#changelist .field-state_toggle .state_toggle a {
+#changelist .field-state_toggle .state_toggle a,
+.grp-change-list .field-state_toggle .state_toggle a {
     display: inline-block;
+    border: 1px solid transparent;
+    padding: 0 2px;
 }
-#changelist .field-state_toggle .state_toggle a[data-state="0"] {
-    width: 100px;
+#changelist .field-state_toggle .state_toggle a[data-state],
+.grp-change-list .field-state_toggle .state_toggle a[data-state] {
+    margin-right: 15px;
 }
-#changelist .field-state_toggle .state_toggle a[data-state="1"] {
-    width: 54px;
+#changelist .field-state_toggle .state_toggle a[data-state]:last-child,
+.grp-change-list .field-state_toggle .state_toggle a[data-state]:last-child {
+    margin-right: 0;
 }
-#changelist .field-state_toggle .state_toggle a[data-state="3"] {
-    width: 38px;
+#changelist .field-state_toggle .state_toggle a.active,
+.grp-change-list .field-state_toggle .state_toggle a.active {
+    text-decoration: none;
+    border-color: inherit;
 }
-#changelist .field-state_toggle .state_toggle a.active {
-    font-weight: bold;
+#changelist .field-state_toggle .state_toggle a.error,
+.grp-change-list .field-state_toggle .state_toggle a.error{
+    color: red;
+}
+#changelist .field-state_toggle .state_toggle a.working,
+.grp-change-list .field-state_toggle .state_toggle a.working{
+    color: gray;
 }
 
 /* misc */

--- a/experiments/static/experiments/dashboard/css/admin.css
+++ b/experiments/static/experiments/dashboard/css/admin.css
@@ -172,6 +172,26 @@ body.change-form #admin_conditionals-group .inline-related.last-related .form-ro
     border: none;
 }
 
+/* remote expderiments state toggle */
+#changelist .field-state_toggle .state_toggle {
+    white-space: nowrap;
+}
+#changelist .field-state_toggle .state_toggle a {
+    display: inline-block;
+}
+#changelist .field-state_toggle .state_toggle a[data-state="0"] {
+    width: 100px;
+}
+#changelist .field-state_toggle .state_toggle a[data-state="1"] {
+    width: 54px;
+}
+#changelist .field-state_toggle .state_toggle a[data-state="3"] {
+    width: 38px;
+}
+#changelist .field-state_toggle .state_toggle a.active {
+    font-weight: bold;
+}
+
 /* misc */
 body.experiments-experiment table.relevant-goals,
 body.model-experiment table.relevant-goals {

--- a/experiments/static/experiments/dashboard/css/admin.css
+++ b/experiments/static/experiments/dashboard/css/admin.css
@@ -183,6 +183,7 @@ body.change-form #admin_conditionals-group .inline-related.last-related .form-ro
 #changelist .field-state_toggle .state_toggle a,
 .grp-change-list .field-state_toggle .state_toggle a {
     display: inline-block;
+    position: relative;
     border: 1px solid transparent;
     padding: 0 2px;
 }
@@ -200,13 +201,42 @@ body.change-form #admin_conditionals-group .inline-related.last-related .form-ro
     border-color: inherit;
 }
 #changelist .field-state_toggle .state_toggle a.error,
-.grp-change-list .field-state_toggle .state_toggle a.error{
+.grp-change-list .field-state_toggle .state_toggle a.error {
     color: red;
 }
 #changelist .field-state_toggle .state_toggle a.working,
-.grp-change-list .field-state_toggle .state_toggle a.working{
-    color: gray;
+.grp-change-list .field-state_toggle .state_toggle a.working {
+    color: black;
+    cursor: default;
 }
+#changelist .field-state_toggle .state_toggle a.really,
+.grp-change-list .field-state_toggle .state_toggle a.really,
+#changelist .field-state_toggle .state_toggle a.really.working,
+.grp-change-list .field-state_toggle .state_toggle a.really.working {
+    color: transparent;
+}
+#changelist .field-state_toggle .state_toggle a.really::after,
+.grp-change-list .field-state_toggle .state_toggle a.really::after,
+#changelist .field-state_toggle .state_toggle a.really.working::after,
+.grp-change-list .field-state_toggle .state_toggle a.really.working::after {
+    position: absolute;
+    color: black !important;
+    left: 0;
+    right: 0;
+    top: 0;
+    margin: 0 -10px;
+    text-align: center;
+    color: inherit;
+}
+#changelist .field-state_toggle .state_toggle a.really::after,
+.grp-change-list .field-state_toggle .state_toggle a.really::after {
+    content: "Confirm?";
+}
+#changelist .field-state_toggle .state_toggle a.really.working::after,
+.grp-change-list .field-state_toggle .state_toggle a.really.working::after {
+    content: "Working...";
+}
+
 
 /* misc */
 body.experiments-experiment table.relevant-goals,

--- a/experiments/static/experiments/dashboard/js/change_list.js
+++ b/experiments/static/experiments/dashboard/js/change_list.js
@@ -1,33 +1,51 @@
-
 (function($) {
 
     $(function() {
 
         var $a = $('.state_toggle > a');
         var URL_TEMPLATE = '/experiments/api/v1/remote_experiment/EXPERIMENT_ID/state/';
+        var CONFIRMATION_TIMEOUT = 1000;  // milliseconds
+        var UI_TIMEOUT = 1000;  // milliseconds
 
         var stateToggleClickHandler = function(event) {
             event.preventDefault();
-
             var $this = $(this);
             if ($this.hasClass('working')) return;
+            if ($this.hasClass('really')) {
+                executeStageChange($this);
+            } else {
+                $this.parent().children().removeClass('really');
+                $this.addClass('really');
+                setTimeout(
+                    function() { notConfirmedTimeout($this); },
+                    CONFIRMATION_TIMEOUT
+                )
+            }
+        };
+
+        var executeStageChange = function($this) {
             var $siblings = $this.parent().children();
             var experimentID = $this.data('id');
             var state = $this.data('state');
             var url = URL_TEMPLATE.replace('EXPERIMENT_ID', experimentID);
+
             $siblings.addClass('working');
-            $.ajax(
-                url,
-                {
-                    method: 'PATCH',
-                    contentType: 'application/json',
-                    timeout: 3000,  // milliseconds
-                    data: JSON.stringify({state: state})
-                }
+
+            $.when(
+                $.ajax(
+                    url,
+                    {
+                        method: 'PATCH',
+                        contentType: 'application/json',
+                        timeout: 3000,  // milliseconds
+                        data: JSON.stringify({state: state})
+                    }
+                ),
+                createDelay(UI_TIMEOUT)
             )
-            .done(function(data) {
-                var newState = data.state;
-                console.info(newState, $this.data('state'));
+            .done(function(ajax_result) {
+                var response = ajax_result[0];
+                var newState = response.state;
                 if (newState !== $this.data('state')) {
                     $siblings.addClass('error');
                 } else {
@@ -38,11 +56,23 @@
             })
             .fail(function() {
                 $siblings.removeClass('active');
-                $this.parent().children().addClass('error');
+                $siblings.addClass('error');
             })
             .always(function() {
                 $siblings.removeClass('working');
+                $siblings.removeClass('really');
             });
+        };
+
+        var notConfirmedTimeout = function($this) {
+            if ($this.hasClass('working')) return;
+            $this.removeClass('really');
+        };
+
+        var createDelay = function(timeout) {
+            var delay = $.Deferred();
+            setTimeout(function() { delay.resolve(); }, timeout);
+            return delay;
         };
 
         $a.on('click', stateToggleClickHandler);

--- a/experiments/static/experiments/dashboard/js/change_list.js
+++ b/experiments/static/experiments/dashboard/js/change_list.js
@@ -1,0 +1,40 @@
+
+(function($) {
+
+    $(function() {
+
+        var $a = $('.state_toggle > a');
+        var URL_TEMPLATE = '/experiments/api/v1/remote_experiment/EXPERIMENT_ID/state/';
+
+        var stateToggleClickHandler = function(event) {
+            event.preventDefault();
+
+            var $this = $(this);
+            var experimentID = $this.data('id');
+            var state = $this.data('state');
+            var url = URL_TEMPLATE.replace('EXPERIMENT_ID', experimentID);
+            $.ajax(
+                url,
+                {
+                    method: 'PATCH',
+                    contentType: 'application/json',
+                    data: JSON.stringify({state: state})
+                }
+            )
+                .done(function() {
+                    console.info( "success" );
+                })
+                .fail(function() {
+                    console.info( "error" );
+                })
+                .always(function() {
+                    console.info( "complete" );
+                });
+        };
+
+        $a.on('click', stateToggleClickHandler);
+
+
+    });
+
+})(django.jQuery);

--- a/experiments/static/experiments/dashboard/js/change_list.js
+++ b/experiments/static/experiments/dashboard/js/change_list.js
@@ -10,30 +10,42 @@
             event.preventDefault();
 
             var $this = $(this);
+            if ($this.hasClass('working')) return;
+            var $siblings = $this.parent().children();
             var experimentID = $this.data('id');
             var state = $this.data('state');
             var url = URL_TEMPLATE.replace('EXPERIMENT_ID', experimentID);
+            $siblings.addClass('working');
             $.ajax(
                 url,
                 {
                     method: 'PATCH',
                     contentType: 'application/json',
+                    timeout: 3000,  // milliseconds
                     data: JSON.stringify({state: state})
                 }
             )
-                .done(function() {
-                    console.info( "success" );
-                })
-                .fail(function() {
-                    console.info( "error" );
-                })
-                .always(function() {
-                    console.info( "complete" );
-                });
+            .done(function(data) {
+                var newState = data.state;
+                console.info(newState, $this.data('state'));
+                if (newState !== $this.data('state')) {
+                    $siblings.addClass('error');
+                } else {
+                    $siblings.removeClass('error');
+                }
+                $siblings.removeClass('active');
+                $siblings.filter('[data-state="' + newState + '"]').addClass('active');
+            })
+            .fail(function() {
+                $siblings.removeClass('active');
+                $this.parent().children().addClass('error');
+            })
+            .always(function() {
+                $siblings.removeClass('working');
+            });
         };
 
         $a.on('click', stateToggleClickHandler);
-
 
     });
 

--- a/experiments/templates/admin/experiments/remoteexperiment/change_list.html
+++ b/experiments/templates/admin/experiments/remoteexperiment/change_list.html
@@ -1,8 +1,10 @@
 {% extends "admin/change_list.html" %}
 {% load static %}
 
-{% block extrastyle %}
+{% block extrahead %}
     {{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static "experiments/dashboard/css/admin.css" %}" />
-{% endblock extrastyle %}
+    <script src="{% static "experiments/dashboard/js/csrf.js" %}"></script>
+    <script src="{% static "experiments/dashboard/js/change_list.js" %}"></script>
+{% endblock extrahead %}
 

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,9 @@ setup(
         'django-jinja>=2.3.1',
         'six>=1.10.0',
         'lxml>=4.1.1,<5',
-        'djangorestframework==3.6.4',
+        'djangorestframework>=3.6.4,<3.7',
         'requests>2.18,<2.19',
+        'Markdown>=2.6.10,<2.7',
     ],
     tests_require=[
         'mock>=1.0.1',


### PR DESCRIPTION
# RED-10

## Overview

When I manage experiments from the new multi-site dashboard (RED-8), I want to be able to turn individual experiments on of off without having to click through and open individual experiment's admin page.

## Description

This PR adds a jQuery toggle (yes I know, jQuery, right?!) to the new dashboard (the dashboard is basically a django-admin changelist view).

## Tests

### Sites

Set up the main site and Mathcingtool to run simultaneously on localhost (gosh, QA has it sooo easy :) )

Then get a token from both sites:
 * create a superuser if don't have one already
 * go to admin, add new token, select the superuser, save, copy the key
 * or via shell: `Token.objects.create(user=User.objects.get(username="dasuperuser")).key`

Then add those keys to `local_settings.py` on the main site like so:
```
EXPERIMENTS_API = {
    'api_mode': 'client,server',
    'local': {
        'name': 'Consumeraffairs Local',
        'page_size': 100,
    },
    'remotes': [
        {
            'url': 'http://localhost:8000',
            'token': 'TOKEN FROM MAIN SITE',
        },
        {
            'url': 'http://localhost:8001',
            'token': 'TOKEN FROM MT',
        },
    ],
}
```

Also add these settings to `thewiz/settings/local/py` on MT:
```
EXPERIMENTS_API = {
    'api_mode': 'server',
    'local': {
        'name': 'MatchingTool Local',
        'page_size': 100,
    },
    'remotes': [],
}
```

#### Shell commands

Run `./manage.py migrate` on both sites

If running nginx, don't forget to `./manage.py collectstatic --clear --link --no-post-process --noinput` or some version thereof.

No need to actually `gulp b` anything.

#### Add some tests

Go to `/admin/experiments/experiment/` on both sites and make sure there are at least some experiments on both sites. Feel free to add a few via the admin (won't actually have any effect on FE, yet, but it won't hurt either).

### Tests

- [ ] Test 1 - The dashboard
1. On the main site, open `/admin/experiments`, and verify that:
    * there is a new option present: `Remote Experiments`
2. Click on `Remote Experiments`, and verify that:
    * There are no errors displayed above the list
    * the list contains experiments from both sites
3. Click on an experiment from the main site(`Consumeraffairs Local`), and verify that:
    * It opens in a new tab
    * note the state of the experiment (`Default/Control`, `Track` or `Enabled`)
4. Close this tab, (should now have the list of Remote Experiments open), and verify that:
    * The state marked for this experiment matches the one from previous step ☝️ 
5. Click another of the two available states, and verify that:
    * you see `Confirm?` prompt for about 1 second, then it reverts back
6. Click that option, then again to confirm, and verify that:
    * the clicked state is now marked.
7. Open the experiment and verify that:
    * the state matches the one selected in previous step ☝️ 


  