### PR TITLE
Red 21 Add export for experiment data from any test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ Dependencies
 - `Redis <http://redis.io/>`_
 - `django-jsonfield <https://github.com/dmkoch/django-jsonfield/>`_
 - `django-modeldict <https://github.com/disqus/django-modeldict>`_
+- `django-import-export<https://github.com/django-import-export/django-import-export>`_
 
 (Detailed list in setup.py)
 
@@ -83,9 +84,11 @@ Next, activate the apps by adding them to your INSTALLED_APPS:
         'django.contrib.admin',
         'django.contrib.humanize',
         'experiments',
+        'import_export',
     ]
 
 Include 'django.contrib.humanize' as above if not already included.
+Include 'import_export' below 'experiments'.
 
 Include the app URLconf in your urls.py file:
 

--- a/experiments/admin.py
+++ b/experiments/admin.py
@@ -62,7 +62,6 @@ class ExperimentResource (ModelResource):
             if goal_value['is_primary']:
                 stats.append(self._parse_alternatives(
                     goal_name, goal_value['alternatives'], 'confidence'))
-        import ipdb; ipdb.set_trace()
         return ', '.join(stats)
 
     def dehydrate_conversion(self, experiment):
@@ -79,7 +78,6 @@ class ExperimentResource (ModelResource):
         return ', '.join(conversions)
 
     def _parse_alternatives(self, goal_name, alternatives, key):
-        import pdb; pdb.set_trace()
         return ', '.join(
             '{0}/{1}: {2}'.format(goal_name, alt_name, alt_data[key])
             for alt_name, alt_data in alternatives

--- a/experiments/admin.py
+++ b/experiments/admin.py
@@ -46,6 +46,7 @@ class ExperimentResource (ModelResource):
         model = Experiment
         fields = ('name', 'start_date', 'end_date', 'state', 'traffic',
             'statistic', 'conversion')
+        export_order = fields
 
     def dehydrate_traffic(self, experiment):
         traffic_context = get_experiment_stats(experiment)['alternatives']

--- a/experiments/admin.py
+++ b/experiments/admin.py
@@ -45,7 +45,7 @@ class ExperimentAlternativeInline(admin.TabularInline):
 
 
 class ExperimentResource(ModelResource):
-    created_date = import_export.fields.Field(column_name="created date")
+    created_date = import_export.fields.Field(column_name="created_date")
     state = import_export.fields.Field(column_name='state')
     participants = import_export.fields.Field(column_name='participants')
     statistic = import_export.fields.Field(column_name='statistic')

--- a/experiments/admin.py
+++ b/experiments/admin.py
@@ -44,7 +44,7 @@ class ExperimentAlternativeInline(admin.TabularInline):
     extra = 0
 
 
-class ExperimentResource (ModelResource):
+class ExperimentResource(ModelResource):
     created_date = import_export.fields.Field(column_name="created date")
     state = import_export.fields.Field(column_name='state')
     participants = import_export.fields.Field(column_name='participants')

--- a/experiments/admin.py
+++ b/experiments/admin.py
@@ -64,6 +64,8 @@ class ExperimentResource (ModelResource):
                     goal_name, goal_value['alternatives'], 'confidence'))
         import ipdb; ipdb.set_trace()
         return ', '.join(stats)
+
+    def dehydrate_conversion(self, experiment):
         conversion_context = get_experiment_stats(experiment)['results']
         conversions = []
         for goal_name, goal_value in conversion_context.items():
@@ -71,8 +73,9 @@ class ExperimentResource (ModelResource):
                 conversions.append(self._parse_alternatives(
                     goal_name, goal_value['alternatives'], 'conversions'))
                 # For every goal there is one control which has a conversion
+                control_alternative = ['control', goal_value['control']]
                 conversions.append(self._parse_alternatives(
-                    goal_name, [goal_value['control']], 'conversions'))
+                    goal_name, [control_alternative], 'conversions'))
         return ', '.join(conversions)
 
     def _parse_alternatives(self, goal_name, alternatives, key):

--- a/experiments/api/admin.py
+++ b/experiments/api/admin.py
@@ -4,6 +4,7 @@ import logging
 from django.contrib import admin
 
 from experiments.consts import STATES
+from experiments.utils import format_percentage
 from .models import RemoteExperiment
 
 
@@ -78,8 +79,7 @@ class RemoteExperimentAdmin(admin.ModelAdmin):
 
         def _td(data):
             confidence = data['confidence']
-            value = '{0:.2f}%'.format(confidence) if confidence else 'N/A'
-            return '<td>{}</td>'.format(value)
+            return '<td>{}</td>'.format(format_percentage(confidence))
 
         def _goal(name, data):
             data_dict = dict(data['alternatives'])

--- a/experiments/static/import_export/action_formats.js
+++ b/experiments/static/import_export/action_formats.js
@@ -1,0 +1,25 @@
+// Changes submitted in PR:
+// https://github.com/django-import-export/django-import-export/pull/719
+// If that has been merged & published, remove this file. Also update version of the dependency in setup.py.
+(function($) {
+  $(document).on('ready', function() {
+    var $actionsSelect, $formatsElement;
+    if ($('body').hasClass('grp-change-list')) {
+        // using grappelli
+        $actionsSelect = $('#grp-changelist-form select[name="action"]');
+        $formatsElement = $('#grp-changelist-form select[name="file_format"]');
+    } else {
+        // using default admin
+        $actionsSelect = $('#changelist-form select[name="action"]');
+        $formatsElement = $('#changelist-form select[name="file_format"]').parent();
+    }
+    $actionsSelect.on('change', function() {
+      if ($(this).val() === 'export_admin_action') {
+        $formatsElement.show();
+      } else {
+        $formatsElement.hide();
+      }
+    });
+    $actionsSelect.change();
+  });
+})(django.jQuery);

--- a/experiments/tests/test_admin.py
+++ b/experiments/tests/test_admin.py
@@ -5,7 +5,8 @@ import json
 from django.contrib.auth.models import User, Permission
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from experiments.admin import ExperimentAdmin
+from django.utils import timezone
+from experiments.admin import ExperimentAdmin, ExperimentResource
 
 from experiments.models import Experiment, CONTROL_STATE, ENABLED_STATE
 from experiments.utils import participant
@@ -119,20 +120,92 @@ class AdminTestCase(TestCase):
 class ExperimentResourceTestCase(TestCase):
 
     def setUp(self):
-        self.experiment = Experimentobjects.create(name='test_experiment',
-            state=ENABLED_STATE)
-        user = User.objects.create_superuser(username='user', email='deleted@mixcloud.com', password='pass')
-        self.client.login(username='user', password='pass')
+        self.experiment = Experiment.objects.create(
+            name='test_experiment',
+            state=ENABLED_STATE,
+            start_date=timezone.datetime(2017,12,21),
+        )
+        self.experiment_resource = ExperimentResource()
+        self.stat = {
+            'alternatives': [('control', 10), ('alt1', 100), ('alt2', 1000)],
+            'results': {
+                'test_goal_1': {
+                    'control': {
+                        'conversions': 1,
+                        'average_goal_actions': 1.0,
+                        'conversion_rate': 100.0
+                    },
+                    'relevant': True,
+                    'is_primary': True,
+                    'alternatives': [('alt1', {
+                        'conversions': 0,
+                        'confidence': None,
+                        'mann_whitney_confidence': None
+                    }), ('alt2', {
+                        'conversions': 1,
+                        'confidence': None,
+                        'mann_whitney_confidence': None
+                    })],
+                },
+                'test_goal_2': {
+                    'control': {
+                        'conversions': 0,
+                        'average_goal_actions': None,
+                        'conversion_rate': 0.0
+                    },
+                    'relevant': True,
+                    'is_primary': True,
+                    'alternatives': [('alt1', {
+                        'conversions': 0,
+                        'confidence': None,
+                        'mann_whitney_confidence': None
+                    }), ('alt2', {
+                        'conversions': 1,
+                        'confidence': 84.27007929422173,
+                        'mann_whitney_confidence': None
+                    })],
+                },
+                'test_goal_3': {
+                    'control': {
+                        'conversions': 0,
+                        'average_goal_actions': None,
+                        'conversion_rate': 0.0
+                    },
+                    'relevant': True,
+                    'is_primary': False,
+                    'alternatives': [('alt1', {
+                        'conversions': 0,
+                        'confidence': None,
+                        'mann_whitney_confidence': None
+                    }), ('alt2', {
+                        'conversions': 1,
+                        'confidence': 0.0001,
+                        'mann_whitney_confidence': None
+                    })],
+                }
+            },
+        }
 
-        participant(user=user).enroll('test_experiment', alternatives=['other1', 'other2'])
+    def test_dehydrate_created_date(self):
+        actual = self.experiment_resource.dehydrate_created_date(
+            self.experiment)
+        expected = "2017-12-21"
 
-        for alternative in ('other2', 'control', 'other1'):
-            response = self.client.post(reverse('admin:experiment_admin_set_alternative'), {
-                'experiment': experiment.name,
-                'alternative': alternative,
-            })
-            self.assertDictEqual(json.loads(response.content.decode('utf-8')), {
-                'success': True,
-                'alternative': alternative,
-            })
-            self.assertEqual(participant(user=user).get_alternative('test_experiment'), alternative)
+        self.assertEqual(expected, actual)
+
+    def test_dehydrate_state(self):
+        actual = self.experiment_resource.dehydrate_state(self.experiment)
+        expected = "Enabled"
+
+        self.assertEqual(expected, actual)
+
+    @mock.patch('experiments.admin.get_experiment_stats')
+    def test_dehydrate_participants(self, get_experiment_stats):
+        get_experiment_stats.return_value = self.stat
+
+        actual = self.experiment_resource.dehydrate_participants(
+            self.experiment)
+        expected = "control: 10, \nalt1: 100, \nalt2: 1000"
+
+        get_experiment_stats.assert_called_once_with(self.experiment)
+        self.assertEqual(expected, actual)

--- a/experiments/utils.py
+++ b/experiments/utils.py
@@ -510,4 +510,8 @@ class SessionUser(WebUser):
         self.session['experiments_enrollments'] = enrollments
 
 
+def format_percentage(value):
+    return '{0:.2f}%'.format(value) if value else 'N/A'
+
+
 __all__ = ['participant']

--- a/experiments/utils.py
+++ b/experiments/utils.py
@@ -511,7 +511,7 @@ class SessionUser(WebUser):
 
 
 def format_percentage(value):
-    return '{0:.2f}%'.format(value) if value else 'N/A'
+    return '{0:.2f}%'.format(value) if value is not None else 'N/A'
 
 
 __all__ = ['participant']

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'django-jsonfield>=1.0.1',
         'redis>=2.4.9',
         'django-jinja>=2.3.1',
+        'django-import-export==0.5.1',
         'six>=1.10.0',
         'lxml>=4.1.1,<5',
         'djangorestframework>=3.6.4,<3.7',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     include_package_data=True,
     license='MIT',
     install_requires=[
-        'django>=1.8',
+        'django>=1.8,<2',
         'django-modeldict-yplan>=1.5.0',
         'django-jsonfield>=1.0.1',
         'redis>=2.4.9',


### PR DESCRIPTION
# RED-21

## Story

Add export for experiment data from any individual test or all A/B/C or Multivariate tests

## Overview
Fields
-  Test name
-  When Started
-  When Stopped
-  When Created
-  Statistical Significance for each measurement
-  Level of traffic to each variate
-  Number of "conversions" for each variate

## Acceptance Criteria

 - [ ] Fields Delivered via CSV export of database data

## How to test

### Tests
**NOTE:** 
For every goal (under `Relevant Goals` in [http://localhost/admin/experiments/experiment/<experiment_name>/change/](http://localhost/admin/experiments/experiment/<experiment_name>/change/)) there are alternatives which makes up the naming convention used in data populated on `statistic` and `conversion` field. However, control is only used in `conversion`
If in the experiment's `Relevant Goals` are not checked under `PRI` then the `statistic` and `conversion` will not be exported.
![screen shot 2017-12-29 at 5 49 13 pm](https://user-images.githubusercontent.com/25109943/34449699-d2f79572-ecc0-11e7-8877-01be52bce79c.png)

- [x] Test 1 - Check that in CA admin the CSV export of experiment data has all the required fields
1. Open [http://localhost/admin/experiments/experiment/](http://localhost/admin/experiments/experiment/) 
2. Make sure that there is an experiment. If not create another experiment.
3. Check that there is a dropdown for `Action:` that looks like the following picture:
![screen shot 2017-12-29 at 5 39 26 pm](https://user-images.githubusercontent.com/25109943/34449593-5e06fcae-ecbf-11e7-9a74-8e593c0f001b.png)
4. In the Action dropdown select `Export selected experiments` and confirm that `Format` dropdown appears as in the following picture:
![screen shot 2017-12-29 at 5 38 20 pm](https://user-images.githubusercontent.com/25109943/34449614-9fa7ef10-ecbf-11e7-9cf9-cbab3701d410.png)
5. In the Format dropdown select `csv` and check one of the experiment then click `Go`.
6. Confirm that a csv file is downloaded with following fields in columns (in order): name, created_date, end_date, state, participants, statistic, conversion

- [x] Test 2 - Check that in CA admin the CSV export of experiment data has all the required fields but have `statistic`and `conversion` field as empty when `PRI` is not checked

- [x] Test 3 - Check that in MT admin the CSV export of experiment data has all the required fields
  