### PR TITLE
PDQ-234 Setting csrfToken to allow making async requests in the mainsite

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -307,10 +307,10 @@ This will be fired when the user loads the page. This is not the only way of fir
         <button onclick="experiments.goal('registration')">Complete Registration</button>
 
     If your project uses CSRF protection (and it should), you will need to send
-``X-CSRFToken`` HTTP header along with the AJAX request. Django-experiments 
-provides a hook that will be called before making the AJAX request. To use it, 
-create a function called ``experimentsCsrfToken`` and have it return the value
-of the token. For example:
+    ``X-CSRFToken`` HTTP header along with the AJAX request. Django-experiments 
+    provides a hook that will be called before making the AJAX request. To use it, 
+    create a function called ``experimentsCsrfToken`` and have it return the value
+    of the token. For example:
 
     ::
 
@@ -318,7 +318,7 @@ of the token. For example:
             return experiments.getCookie('');
         }
 
-    For more info please see the `Django Docs <https://docs.djangoproject.com/en/1.4/ref/contrib/csrf/#ajax>`_)
+    For more info please see the `Django Docs <https://docs.djangoproject.com/en/1.4/ref/contrib/csrf/#ajax>`_
 
 
 4. **Cookies**:

--- a/README.rst
+++ b/README.rst
@@ -313,12 +313,12 @@ create a function called ``experimentsCsrfToken`` and have it return the value
 of the token. For example:
 
     ::
-    
+
         function experimentsCsrfToken() {
             return experiments.getCookie('');
         }
 
-For more info please see the `Django Docs <https://docs.djangoproject.com/en/1.4/ref/contrib/csrf/#ajax>`_)
+    For more info please see the `Django Docs <https://docs.djangoproject.com/en/1.4/ref/contrib/csrf/#ajax>`_)
 
 
 4. **Cookies**:

--- a/README.rst
+++ b/README.rst
@@ -306,7 +306,20 @@ This will be fired when the user loads the page. This is not the only way of fir
 
         <button onclick="experiments.goal('registration')">Complete Registration</button>
 
-    (Please note, this requires CSRF authentication. Please see the `Django Docs <https://docs.djangoproject.com/en/1.4/ref/contrib/csrf/#ajax>`_)
+    If your project uses CSRF protection (and it should), you will need to send
+``X-CSRFToken`` HTTP header along with the AJAX request. Django-experiments 
+provides a hook that will be called before making the AJAX request. To use it, 
+create a function called ``experimentsCsrfToken`` and have it return the value
+of the token. For example:
+
+    ::
+    
+        function experimentsCsrfToken() {
+            return experiments.getCookie('');
+        }
+
+For more info please see the `Django Docs <https://docs.djangoproject.com/en/1.4/ref/contrib/csrf/#ajax>`_)
+
 
 4. **Cookies**:
 

--- a/experiments/static/experiments/dashboard/js/csrf.js
+++ b/experiments/static/experiments/dashboard/js/csrf.js
@@ -15,10 +15,10 @@
 
     function getCookie(name) {
         var cookieValue = null;
-        if (document.cookie && document.cookie != '') {
+        if (document.cookie) {
             var cookies = document.cookie.split(';');
             for (var i = 0; i < cookies.length; i++) {
-                var cookie = $.trim(cookies[i]);
+                var cookie = cookies[i] ? cookies[i].trim() : '';
                 // Does this cookie string begin with the name we want?
                 if (cookie.substring(0, name.length + 1) == (name + '=')) {
                     cookieValue = decodeURIComponent(cookie.substring(name.length + 1));

--- a/experiments/static/experiments/js/experiments.js
+++ b/experiments/static/experiments/js/experiments.js
@@ -16,7 +16,7 @@ experiments = function() {
             this.csrfToken = experimentsCsrfToken && experimentsCsrfToken();
             xhr.open('POST', '/experiments/goal/' + goal_name + '/');
             xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-            if(this.csrfToken) {
+            if (this.csrfToken) {
                 xhr.setRequestHeader('X-CSRFToken', this.csrfToken);
             }
             xhr.onload = function() {
@@ -28,7 +28,7 @@ experiments = function() {
         },
         getCookie: function(name) {
             var cookieValue = null;
-            if (document.cookie && document.cookie != '') {
+            if (document.cookie) {
                 var cookies = document.cookie.split(';');
                 for (var i = 0; i < cookies.length; i++) {
                     var cookie = cookies[i] ? cookies[i].trim() : '';

--- a/experiments/static/experiments/js/experiments.js
+++ b/experiments/static/experiments/js/experiments.js
@@ -13,15 +13,35 @@ experiments = function() {
         },
         goal: function(goal_name) {
             var xhr = new XMLHttpRequest();
+            this.csrfToken = experimentsCsrfToken && experimentsCsrfToken();
             xhr.open('POST', '/experiments/goal/' + goal_name + '/');
             xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+            if(this.csrfToken) {
+                xhr.setRequestHeader('X-CSRFToken', this.csrfToken);
+            }
             xhr.onload = function() {
                 if (xhr.status !== 200) {
                     throw 'POST to "/experiments/goal/" failed. Returned status of ' + xhr.status;
                 }
             };
             xhr.send();
-        }
+        },
+        getCookie: function(name) {
+            var cookieValue = null;
+            if (document.cookie && document.cookie != '') {
+                var cookies = document.cookie.split(';');
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookie = cookies[i] ? cookies[i].trim() : '';
+                    // Does this cookie string begin with the name we want?
+                    if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        },
+        csrfToken: null
     };
 }();
 


### PR DESCRIPTION
# PDQ-234

## Context
After trying to setup the experiments on the main site we realized we're having inconvenients to make asynchronous post requests due to a csrf token issue. To solve the issue we're adding a request header to send it.

## Acceptance criteria
- [ ] Make sure we can set goals on the matching tools using `experiments.goal()`
- [ ] Make sure we can set goals on the main site using `experiments.goal()`

## Test instructions
- [ ] Bump the version for the experiments repo

- [ ] Test in matching tool
  - Click on an element that is tracking a goal on click
  - Make sure the click is tracked in the admin on experiments
